### PR TITLE
Added /msg lykos give target for shaman and crazed

### DIFF
--- a/htdocs/commands.html
+++ b/htdocs/commands.html
@@ -115,6 +115,12 @@
         </td>
       </tr>
       <tr>
+        <td>/msg lykos give <em>target</em></td>
+        <td>Shaman and Crazed shaman</td>
+        <td>Night</td>
+        <td>Gives a totem to <em>target</em>. Crazed shaman's totem is randomly selected, only shaman knows what totem they are giving to <em>target</em>.</td>
+      </tr>
+      <tr>
         <td>/msg lykos visit <em>target</em></td>
         <td>Harlot</td>
         <td>Night</td>


### PR DESCRIPTION
Description: Gives a totem to target. Crazed shaman's totem is randomly selected, only shaman knows what totem they are giving to target.
